### PR TITLE
Fix binary compatibility in demo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <description>Integration of google-map for Vaadin platform</description>
 
     <properties>
-        <vaadin.version>14.7.5</vaadin.version>
+        <vaadin.version>14.8.20</vaadin.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/test/java/com/flowingcode/vaadin/addons/googlemaps/AddMarkersDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/googlemaps/AddMarkersDemo.java
@@ -55,7 +55,7 @@ public class AddMarkersDemo extends AbstractGoogleMapsDemo {
     markerColorsMap.put("Orange", Markers.ORANGE);
     markerColorsMap.put("Light blue", Markers.LIGHTBLUE);
     ComboBox<String> colorCB = new ComboBox<>();
-    colorCB.setItems(markerColorsMap.keySet());
+    ReflectionUtil.setItems(colorCB, markerColorsMap.keySet());
     colorCB.setPlaceholder("Marker color");
     Button addMarker =
         new Button(

--- a/src/test/java/com/flowingcode/vaadin/addons/googlemaps/ReflectionUtil.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/googlemaps/ReflectionUtil.java
@@ -1,0 +1,17 @@
+package com.flowingcode.vaadin.addons.googlemaps;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import java.util.Collection;
+
+public class ReflectionUtil {
+
+  /** Reflective call in order to mantain binary compatibility with Vaadin 14 - 24 */
+  static void setItems(ComboBox<String> combobox, Collection<String> items) {
+    try {
+      ComboBox.class.getMethod("setItems", Collection.class).invoke(combobox, items);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}


### PR DESCRIPTION
#87 fixes _source_ compatibility. However `ComboBox.setItems(Collection)` returns `void` in Vaadin 14 and `ComboBoxListDataView` in Vaadin 23+, which results in binary incompatibility when the V14-compiled demo are deployed to Vaadin 23/24 demo sites. Since this error only affects the demo, it doesn't make sense to release a new major version just because of that.
