### PR TITLE
fix: update markers on removal

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMap.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMap.java
@@ -44,7 +44,7 @@ import org.apache.commons.lang3.StringUtils;
 @SuppressWarnings("serial")
 @Tag("google-map")
 @JsModule("@flowingcode/google-map/google-map.js")
-@NpmPackage(value = "@flowingcode/google-map", version = "3.6.0")
+@NpmPackage(value = "@flowingcode/google-map", version = "3.6.1")
 @NpmPackage(value = "@googlemaps/markerclusterer", version = "2.0.8")
 @JsModule("./googlemaps/geolocation.js")
 public class GoogleMap extends Component implements HasSize {
@@ -176,6 +176,8 @@ public class GoogleMap extends Component implements HasSize {
   @SuppressWarnings("squid:S3242")
   public void removeMarker(GoogleMapMarker marker) {
     this.getElement().removeChild(marker.getElement());
+    // markers need to be updated on removal
+    this.getElement().executeJs("this._updateMarkers()");
   }
 
   /**

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapMarker.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapMarker.java
@@ -39,7 +39,7 @@ import elemental.json.JsonValue;
 @SuppressWarnings("serial")
 @Tag("google-map-marker")
 @JsModule("@flowingcode/google-map/google-map-marker.js")
-@NpmPackage(value = "@flowingcode/google-map", version = "3.6.0")
+@NpmPackage(value = "@flowingcode/google-map", version = "3.6.1")
 @NpmPackage(value = "@googlemaps/markerclusterer", version = "2.0.8")
 public class GoogleMapMarker extends Component {
 

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapPoint.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapPoint.java
@@ -28,7 +28,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @SuppressWarnings("serial")
 @Tag("google-map-point")
 @JsModule("@flowingcode/google-map/google-map-point.js")
-@NpmPackage(value = "@flowingcode/google-map", version = "3.6.0")
+@NpmPackage(value = "@flowingcode/google-map", version = "3.6.1")
 @NpmPackage(value = "@googlemaps/markerclusterer", version = "2.0.8")
 public class GoogleMapPoint extends Component {
 

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapPolygon.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapPolygon.java
@@ -40,7 +40,7 @@ import java.util.List;
 @Tag("google-map-poly")
 @JsModule("@flowingcode/google-map/google-map-poly.js")
 @JsModule("@flowingcode/google-map/google-map-point.js")
-@NpmPackage(value = "@flowingcode/google-map", version = "3.6.0")
+@NpmPackage(value = "@flowingcode/google-map", version = "3.6.1")
 @NpmPackage(value = "@googlemaps/markerclusterer", version = "2.0.8")
 public class GoogleMapPolygon extends Component {
 


### PR DESCRIPTION
Update web-component dependency to 3.6.1 so markers in cluster are udpate on removal

Close #109