### PR TITLE
fix: use setProperty instead of setAttribute for zoom property

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMap.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMap.java
@@ -119,7 +119,7 @@ public class GoogleMap extends Component implements HasSize {
    * @param zoom New amount of the zoom.
    */
   public void setZoom(int zoom) {
-    this.getElement().setAttribute("zoom", Integer.toString(zoom));
+    this.getElement().setProperty("zoom", zoom);
   }
 
   /**


### PR DESCRIPTION
Close #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the zoom functionality in Google Maps by using a more efficient method to set the zoom level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->