### PR TITLE
feat: add possibility to style map features and elements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flowingcode.vaadin.addons</groupId>
     <artifactId>google-maps</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <name>Google Maps Addon</name>
     <description>Integration of google-map for Vaadin platform</description>
 

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMap.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMap.java
@@ -20,6 +20,9 @@
 
 package com.flowingcode.vaadin.addons.googlemaps;
 
+import com.flowingcode.vaadin.addons.googlemaps.maptypestyle.ElementType;
+import com.flowingcode.vaadin.addons.googlemaps.maptypestyle.FeatureType;
+import com.flowingcode.vaadin.addons.googlemaps.maptypestyle.MapStyle;
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
@@ -849,4 +852,17 @@ public class GoogleMap extends Component implements HasSize {
         .executeJs("document.exitFullscreen();");
   }
   
+  /**
+   * Sets style formatting to the {@link FeatureType features} and {@link ElementType elements} of the map.
+   * 
+   * @param mapStyles formatting to be applied to the map features and elements
+   */
+  public void setMapStyle(MapStyle... mapStyles) {
+    JsonArray jsonArray = Json.createArray();
+    for (int i = 0; i < mapStyles.length; i++) {
+      MapStyle mapStyle = mapStyles[i];
+      jsonArray.set(i, mapStyle.getJson());
+    }
+    this.getElement().setPropertyJson("styles", jsonArray);    
+  } 
 }

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/maptypestyle/ElementType.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/maptypestyle/ElementType.java
@@ -1,0 +1,83 @@
+/*-
+ * #%L
+ * Google Maps Addon
+ * %%
+ * Copyright (C) 2020 - 2024 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.flowingcode.vaadin.addons.googlemaps.maptypestyle;
+
+import lombok.Getter;
+
+/**
+ * Enum representing supported element types. Elements are subdivisions of a feature.
+ */
+public enum ElementType {
+
+  /**
+   * Selects all elements of the specified feature. Is the default option.
+   */
+  ALL("all"),
+
+  /**
+   * Selects all geometric elements of the specified feature.
+   */
+  GEOMETRY("geometry"),
+
+  /**
+   * Selects only the fill of the feature's geometry.
+   */
+  GEOMETRY_FILL("geometry.fill"),
+
+  /**
+   * Selects only the stroke of the feature's geometry.
+   */
+  GEOMETRY_STROKE("geometry.stroke"),
+
+  /**
+   * Selects the textual labels associated with the specified feature.
+   */
+  LABELS("labels"),
+
+  /**
+   * Selects only the icon displayed within the feature's label.
+   */
+  LABELS_ICON("labels.icon"),
+
+  /**
+   * Selects only the text of the label.
+   */
+  LABELS_TEXT("labels.text"),
+
+  /**
+   * Selects only the fill of the label. The fill of a label is typically rendered as a colored
+   * outline that surrounds the label text.
+   */
+  LABELS_TEXT_FILL("labels.text.fill"),
+
+  /**
+   * Selects only the stroke of the label's text.
+   */
+  LABELS_TEXT_STROKE("labels.text.stroke");
+
+  @Getter
+  private String value;
+
+  ElementType(String value) {
+    this.value = value;
+  }
+
+}

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/maptypestyle/FeatureType.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/maptypestyle/FeatureType.java
@@ -1,0 +1,208 @@
+/*-
+ * #%L
+ * Google Maps Addon
+ * %%
+ * Copyright (C) 2020 - 2024 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.flowingcode.vaadin.addons.googlemaps.maptypestyle;
+
+import lombok.Getter;
+
+/**
+ * Enum representing supported feature types. Features are geographic characteristics on the
+ * map, including roads, parks, bodies of water, businesses, and more.
+ */
+public enum FeatureType {
+
+  /**
+   * Selects all features. Is the default option.
+   */
+  ALL("all"),
+
+  /**
+   * Selects all administrative areas. Styling affects only the labels of administrative areas, not
+   * the geographical borders or fill.
+   */
+  ADMINISTRATIVE("administrative"),
+
+  /**
+   * Selects countries.
+   */
+  ADMINISTRATIVE_COUNTRY("administrative.country"),
+
+  /**
+   * Selects land parcels.
+   */
+  ADMINISTRATIVE_LAND_PARCEL("administrative.land_parcel"),
+
+
+  /**
+   * Selects localities.
+   */
+  ADMINISTRATIVE_LOCALITY("administrative.locality"),
+
+
+  /**
+   * Selects neighborhoods.
+   */
+  ADMINISTRATIVE_NEIGHBORHOOD("administrative.neighborhood"),
+
+
+  /**
+   * Selects provinces.
+   */
+  ADMINISTRATIVE_PROVINCE("administrative.province"),
+
+  /**
+   * Selects all landscapes.
+   */
+  LANDSCAPE("landscape"),
+
+  /**
+   * Selects man-made features, such as buildings and other structures.
+   */
+  LANDSCAPE_MAN_MADE("landscape.man_made"),
+
+  /**
+   * Selects natural features, such as mountains, rivers, deserts, and glaciers..
+   */
+  LANDSCAPE_NATURAL("landscape.natural"),
+
+  /**
+   * Selects land cover features, the physical material that covers the earth's surface, such as
+   * forests, grasslands, wetlands, and bare ground..
+   */
+  LANDSCAPE_NATURAL_LANDCOVER("landscape.natural.landcover"),
+
+  /**
+   * Selects terrain features of a land surface, such as elevation, slope, and orientation.
+   */
+  LANDSCAPE_NATURAL_TERRAIN("landscape.natural.terrain"),
+
+  /**
+   * Selects all points of interest.
+   */
+  POI("poi"),
+
+  /**
+   * Selects tourist attractions.
+   */
+  POI_ATTRACTION("poi.attraction"),
+
+  /**
+   * Selects businesses.
+   */
+  POI_BUSINESS("poi.business"),
+
+  /**
+   * Selects government buildings.
+   */
+  POI_GOVERNMENT("poi.government"),
+
+  /**
+   * Selects emergency services, including hospitals, pharmacies, police, doctors, and others.
+   */
+  POI_MEDICAL("poi.medical"),
+
+  /**
+   * Selects parks.
+   */
+  POI_PARK("poi.park"),
+
+  /**
+   * Selects places of worship, including churches, temples, mosques, and others.
+   */
+  POI_PLACE_OF_WORSHIP("poi.place_of_worship"),
+
+  /**
+   * Selects schools.
+   */
+  POI_SCHOOL("poi.school"),
+
+  /**
+   * Selects sports complexes.
+   */
+  POI_SPORTS_COMPLEX("poi.sports_complex"),
+
+  /**
+   * Selects all roads.
+   */
+  ROAD("road"),
+
+  /**
+   * Selects arterial roads.
+   */
+  ROAD_ARTERIAL("road.arterial"),
+
+  /**
+   * Selects highways.
+   */
+  ROAD_HIGHWAY("road.highway"),
+
+  /**
+   * Selects highways with controlled access.
+   */
+  ROAD_HIGHWAY_CONTROLLED_ACCESS("road.highway.controlled_access"),
+
+  /**
+   * Selects local roads.
+   */
+  ROAD_LOCAL("road.local"),
+
+  /**
+   * Selects all transit stations and lines.
+   */
+  TRANSIT("transit"),
+
+  /**
+   * Selects transit lines.
+   */
+  TRANSIT_LINE("transit.line"),
+
+  /**
+   * Selects transit stations.
+   */
+  TRANSIT_STATION("transit.station"),
+
+  /**
+   * Selects airports.
+   */
+  TRANSIT_STATION_AIRPORT("transit.station.airport"),
+
+  /**
+   * Selects bus stops.
+   */
+  TRANSIT_STATION_BUS("transit.station.bus"),
+
+  /**
+   * Selects rail stations.
+   */
+  TRANSIT_STATION_RAIL("transit.station.rail"),
+
+  /**
+   * Selects bodies of water.
+   */
+  WATER("water");
+
+  @Getter
+  private String value;
+
+  FeatureType(String value) {
+    this.value = value;
+  }
+
+}

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/maptypestyle/MapStyle.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/maptypestyle/MapStyle.java
@@ -1,0 +1,88 @@
+/*-
+ * #%L
+ * Google Maps Addon
+ * %%
+ * Copyright (C) 2020 - 2024 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.flowingcode.vaadin.addons.googlemaps.maptypestyle;
+
+import elemental.json.Json;
+import elemental.json.JsonObject;
+import java.io.Serializable;
+import java.util.Optional;
+
+/**
+ * Representation for the collection of selectors and stylers that define how the map should be
+ * styled.
+ * 
+ * <p>A map style consists of one selector and its corresponding style rules. Selectors specify 
+ * the map features and/or elements that should be affected, while the style rule define how those features 
+ * and elements should be modified by using stylers. </p>
+ * 
+ * <p>This class provides methods to convert the style information into a JSON representation.</p>
+ */
+public class MapStyle implements Serializable {
+
+  private static final long serialVersionUID = -3352482751629553500L;
+
+  private FeatureType featureType;
+
+  private ElementType elementType;
+
+  private StyleRules styleRules;
+
+  /**
+   * Creates a new {@code MapStyle} with the specified feature type and style rules.
+   *
+   * @param featureType the feature type to be styled
+   * @param styleRules the style rules to apply
+   */
+  public MapStyle(FeatureType featureType, StyleRules styleRules) {
+    this.styleRules = styleRules;
+    this.featureType = featureType;
+  }
+
+  /**
+   * Creates a new {@code MapStyle} with the specified feature type, element type, and style rules.
+   *
+   * @param featureType the feature type to be styled
+   * @param elementType the element type to be styled
+   * @param styleRules the style rules to apply
+   */
+  public MapStyle(FeatureType featureType, ElementType elementType, StyleRules styleRules) {
+    this(featureType, styleRules);
+    this.elementType = elementType;
+  }
+
+  /**
+   * Converts the {@code MapStyle} to a JSON object.
+   *
+   * <p>This method includes the feature type, element type, and style rules, if present.</p>
+   *
+   * @return a {@code JsonObject} representing the map style
+   */
+  public JsonObject getJson() {
+    JsonObject jsonObject = Json.createObject();
+    Optional.ofNullable(featureType)
+        .ifPresent(v -> jsonObject.put("featureType", v.getValue()));
+    Optional.ofNullable(elementType)
+        .ifPresent(v -> jsonObject.put("elementType", v.getValue()));
+    Optional.ofNullable(styleRules)
+        .ifPresent(v -> jsonObject.put("stylers", styleRules.getJson()));
+    return jsonObject;
+  }
+}

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/maptypestyle/StyleRules.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/maptypestyle/StyleRules.java
@@ -1,0 +1,137 @@
+/*-
+ * #%L
+ * Google Maps Addon
+ * %%
+ * Copyright (C) 2020 - 2024 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.flowingcode.vaadin.addons.googlemaps.maptypestyle;
+
+import elemental.json.Json;
+import elemental.json.JsonArray;
+import elemental.json.JsonObject;
+import java.io.Serializable;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.Setter;
+
+
+/**
+ * Representation of the formatting options that can be applied to map features and elements.
+ */
+@Getter
+@Setter
+public class StyleRules implements Serializable {
+
+  private static final long serialVersionUID = -7506228136304010510L;
+
+  /**
+   * Indicates whether and how the element appears on the map. Possible values: on, off, or
+   * simplified.
+   */
+  private Visibility visibility;
+
+  /**
+   * An RGB hex string of format #RRGGBB that sets the color of the feature.
+   */
+  private String color;
+
+  /**
+   * An integer value, greater than or equal to zero to sets the weight of the feature, in pixels.
+   */
+  private Integer weight;
+
+  /**
+   * If true it inverts the existing lightness. This is useful, for example, for quickly switching
+   * to a darker map with white text.
+   */
+  private boolean invertLightness;
+
+  /**
+   * Indicates the amount of gamma correction to apply to the element (a floating point value
+   * between 0.01 and 10.0, where 1.0 applies no correction).
+   */
+  private double gamma;
+
+  /**
+   * Indicates the percentage change in intensity of the basic color to apply to the element (a
+   * floating point value between -100 and 100).
+   */
+  private double saturation;
+
+  /**
+   * Indicates the percentage change in brightness of the element (a floating point value between
+   * -100 and 100). Negative values increase darkness (where -100 specifies black) while positive
+   * values increase brightness (where +100 specifies white).
+   */
+  private double lightness;
+
+  /**
+   * An RGB hex string of format #RRGGBB that indicates the basic color.
+   */
+  private String hue;
+
+  /**
+   * Converts {@code StyleRules} to a JSON array.
+   *
+   * @return a {@code JsonArray} representing the style rules array
+   */
+  protected JsonArray getJson() {
+    JsonArray jsonArray = Json.createArray();
+    Optional.ofNullable(visibility).ifPresent(v -> {
+      JsonObject js = Json.createObject();
+      js.put(Stylers.VISIBILITY.getValue(), v.getValue());
+      jsonArray.set(jsonArray.length(), js);
+    });
+    Optional.ofNullable(color).ifPresent(v -> {
+      JsonObject js = Json.createObject();
+      js.put(Stylers.COLOR.getValue(), v);
+      jsonArray.set(jsonArray.length(), js);
+    });
+    Optional.ofNullable(weight).ifPresent(v -> {
+      JsonObject js = Json.createObject();
+      js.put(Stylers.WEIGHT.getValue(), v);
+      jsonArray.set(jsonArray.length(), js);
+    });
+    Optional.ofNullable(invertLightness).ifPresent(v -> {
+      JsonObject js = Json.createObject();
+      js.put(Stylers.INVERT_LIGHTNESS.getValue(), v);
+      jsonArray.set(jsonArray.length(), js);
+    });
+    Optional.ofNullable(gamma).ifPresent(v -> {
+      JsonObject js = Json.createObject();
+      js.put(Stylers.GAMMA.getValue(), v);
+      jsonArray.set(jsonArray.length(), js);
+    });
+    Optional.ofNullable(saturation).ifPresent(v -> {
+      JsonObject js = Json.createObject();
+      js.put(Stylers.SATURATION.getValue(), v);
+      jsonArray.set(jsonArray.length(), js);
+    });
+    Optional.ofNullable(lightness).ifPresent(v -> {
+      JsonObject js = Json.createObject();
+      js.put(Stylers.LIGHTNESS.getValue(), v);
+      jsonArray.set(jsonArray.length(), js);
+    });
+    Optional.ofNullable(hue).ifPresent(v -> {
+      JsonObject js = Json.createObject();
+      js.put(Stylers.HUE.getValue(), v);
+      jsonArray.set(jsonArray.length(), js);
+    });
+    return jsonArray;
+  }
+
+}

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/maptypestyle/Stylers.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/maptypestyle/Stylers.java
@@ -1,0 +1,42 @@
+/*-
+ * #%L
+ * Google Maps Addon
+ * %%
+ * Copyright (C) 2020 - 2024 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.flowingcode.vaadin.addons.googlemaps.maptypestyle;
+
+import lombok.Getter;
+
+/**
+ * Enum representing supported stylers that can be applied to map
+ * features and elements.
+ */
+public enum Stylers {
+  
+  VISIBILITY("visibility"), COLOR("color"), WEIGHT("weight"),
+  INVERT_LIGHTNESS("invert_lightness"), GAMMA("gamma"),
+  SATURATION("saturation"), LIGHTNESS("lightness"), HUE("hue");
+
+  @Getter
+  private String value;
+
+  Stylers(String value) {
+    this.value = value;
+  }
+  
+}

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/maptypestyle/Visibility.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/maptypestyle/Visibility.java
@@ -1,0 +1,39 @@
+/*-
+ * #%L
+ * Google Maps Addon
+ * %%
+ * Copyright (C) 2020 - 2024 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.flowingcode.vaadin.addons.googlemaps.maptypestyle;
+
+import lombok.Getter;
+
+/**
+ * Enum representing the possible values to indicate whether and how the element appears on the map.
+ */
+public enum Visibility {
+
+  ON("on"), OFF("off"), SIMPLIFIED("simplified");
+
+  @Getter
+  private String value;
+
+  Visibility(String value) {
+    this.value = value;
+  }
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/googlemaps/GooglemapsDemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/googlemaps/GooglemapsDemoView.java
@@ -47,6 +47,7 @@ public class GooglemapsDemoView extends TabbedDemo {
     addDemo(PolylinesDemo.class);
     addDemo(CustomizedMarkerIconsDemo.class);
     addDemo(TrackLocationDemo.class);
+    addDemo(StyleFeaturesDemo.class);
     setSizeFull();
   }
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/googlemaps/StyleFeaturesDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/googlemaps/StyleFeaturesDemo.java
@@ -1,0 +1,87 @@
+/*-
+ * #%L
+ * Google Maps Addon
+ * %%
+ * Copyright (C) 2020 - 2024 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.flowingcode.vaadin.addons.googlemaps;
+
+import com.flowingcode.vaadin.addons.demo.DemoSource;
+import com.flowingcode.vaadin.addons.googlemaps.GoogleMap.MapType;
+import com.flowingcode.vaadin.addons.googlemaps.maptypestyle.ElementType;
+import com.flowingcode.vaadin.addons.googlemaps.maptypestyle.FeatureType;
+import com.flowingcode.vaadin.addons.googlemaps.maptypestyle.MapStyle;
+import com.flowingcode.vaadin.addons.googlemaps.maptypestyle.StyleRules;
+import com.flowingcode.vaadin.addons.googlemaps.maptypestyle.Visibility;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+@PageTitle("Style Features")
+@DemoSource
+@Route(value = "googlemaps/stylefeatures", layout = GooglemapsDemoView.class)
+@SuppressWarnings("serial")
+public class StyleFeaturesDemo extends AbstractGoogleMapsDemo {
+
+  @Override
+  protected void createGoogleMapsDemo(String apiKey) {
+    GoogleMap gmaps1 = createGoogleMap(apiKey);
+    VerticalLayout withoutStyleChanges =
+        new VerticalLayout(createSpan("Map without style changes"), gmaps1);
+    withoutStyleChanges.setSizeFull();
+
+    GoogleMap gmaps2 = createGoogleMap(apiKey);
+    VerticalLayout withStyleChanges = new VerticalLayout(
+        createSpan("Hide all POIs and sets color and saturation to labels of the roads"), gmaps2);
+    withStyleChanges.setSizeFull();
+
+    // create rules to hide POIs (points of interest)
+    StyleRules styleRule = new StyleRules();
+    styleRule.setVisibility(Visibility.OFF);
+    MapStyle mapStyle = new MapStyle(FeatureType.POI, styleRule);
+
+    // create rule to style local roads
+    StyleRules styleRule2 = new StyleRules();
+    styleRule2.setColor("#a98fcf");
+    styleRule2.setSaturation(50);
+    MapStyle mapStyle2 = new MapStyle(FeatureType.ROAD, ElementType.LABELS_TEXT_STROKE, styleRule2);
+
+    // add the rules to the map
+    gmaps2.setMapStyle(mapStyle, mapStyle2);
+
+    VerticalLayout verticalLayout = new VerticalLayout(withoutStyleChanges, withStyleChanges);
+    verticalLayout.setSizeFull();
+    add(verticalLayout);
+  }
+
+  private GoogleMap createGoogleMap(String apiKey) {
+    GoogleMap gmaps = new GoogleMap(apiKey, null, null);
+    gmaps.setMapType(MapType.ROADMAP);
+    gmaps.setSizeFull();
+    gmaps.setCenter(new LatLon(-31.635175, -60.698405));
+    gmaps.setZoom(16);
+    return gmaps;
+  }
+
+  private Span createSpan(String text) {
+    Span span = new Span(text);
+    span.getElement().getStyle().set("font-weight", "bold");
+    return span;
+  }
+
+}


### PR DESCRIPTION
Close #123

This PR includes new API that allows to add styling to map features and elements by defining style rules using stylers. 
(See [style-reference](https://developers.google.com/maps/documentation/javascript/style-reference) for more information).

This also includes a new demo call StyleFeaturesDemo that adds an example on how to use this new API. Specifically adds an example of how to hide POIs as it was the original request on #123. The demo features a comparison between a map without any style and a styled one, so differences can be observed and understood better. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new method to customize map styles in the Google Maps component.
	- Added support for defining various element types and feature types for enhanced map styling.
	- Implemented a structured representation for styling rules, allowing detailed visual customization of map elements.
	- Added a demo showcasing the new styling features for Google Maps integration.
	- Updated to version 2.1.0, indicating new enhancements and potential bug fixes.

- **Bug Fixes**
	- Improved handling of visibility settings for map elements in the styling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->