### PR TITLE
docs: update javadocs

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMap.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMap.java
@@ -69,8 +69,7 @@ public class GoogleMap extends Component implements HasSize {
   }
 
   /**
-   * Initiates a new GoogleMap object with default settings from the {@link GoogleMapState state
-   * object}.
+   * Initiates a new GoogleMap object.
    *
    * @param apiKey The Maps API key from Google. Not required when developing in localhost or when
    *     using a client id. Use null or empty string to disable.
@@ -434,7 +433,7 @@ public class GoogleMap extends Component implements HasSize {
   /**
    * Sets a KML or GeoRSS feed url to be displayed as a KML Layer in the map.
    * 
-   * @param url to be displayed.
+   * @param kml the url to be displayed.
    */
   public void setKml(String kml){
     this.getElement().setProperty("kml", kml);


### PR DESCRIPTION
Close #141

Removed "GoogleMapState" from javadoc of constructor as there's no object with that name in the add-on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for setting custom controls, enhancing control management.
  
- **Improvements**
	- Simplified documentation for the GoogleMap constructor and updated parameter names for clarity.
	- Enhanced location tracking management with checks to prevent multiple active sessions.

- **Deprecations**
	- Deprecated the old method for adding custom controls, recommending the new method instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->