### PR TITLE
fix: set marker slot in default constructor to ensure visibility

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapMarker.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapMarker.java
@@ -53,6 +53,7 @@ public class GoogleMapMarker extends Component {
   public GoogleMapMarker() {
     id = idCounter;
     idCounter++;
+    this.getElement().setAttribute("slot", "markers");
   }
 
   /**
@@ -67,7 +68,6 @@ public class GoogleMapMarker extends Component {
     this.setCaption(caption);
     this.setPosition(position);
     this.setDraggable(draggable);
-    this.getElement().setAttribute("slot", "markers");
   }
 
   /**


### PR DESCRIPTION
Close #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency in marker display by ensuring all map markers are correctly assigned to the "markers" slot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->