### PR TITLE
docs: fix link in javadoc

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GeolocationOptions.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GeolocationOptions.java
@@ -29,7 +29,7 @@ import lombok.Setter;
  * Representation of optional parameters for a geolocation request.
  * 
  * @see <a href=
- *      https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition#options">Options
+ *      "https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition#options">Options
  *      documentation</a>
  */
 @Getter


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a broken hyperlink in the geolocation options API documentation; the MDN reference now renders properly.
  * No runtime or API changes; behavior, fields, and methods remain unchanged.
  * Improves developer experience by ensuring accurate, navigable reference material in the generated Javadoc.
  * No action required for upgrades.
  * Compatible with all existing configurations and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->