### PR TITLE
Enable "Touch-and-Hold" Gesture as Right-Click Equivalent on Mobile Devices

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flowingcode.vaadin.addons</groupId>
     <artifactId>google-maps</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <name>Google Maps Addon</name>
     <description>Integration of google-map for Vaadin platform</description>
 

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMap.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMap.java
@@ -50,7 +50,7 @@ import org.apache.commons.lang3.StringUtils;
 @SuppressWarnings("serial")
 @Tag("google-map")
 @JsModule("@flowingcode/google-map/google-map.js")
-@NpmPackage(value = "@flowingcode/google-map", version = "3.8.2")
+@NpmPackage(value = "@flowingcode/google-map", version = "3.9.0")
 @NpmPackage(value = "@googlemaps/markerclusterer", version = "2.0.8")
 @JsModule("./googlemaps/geolocation.js")
 public class GoogleMap extends Component implements HasSize {

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapMarker.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapMarker.java
@@ -39,7 +39,7 @@ import elemental.json.JsonValue;
 @SuppressWarnings("serial")
 @Tag("google-map-marker")
 @JsModule("@flowingcode/google-map/google-map-marker.js")
-@NpmPackage(value = "@flowingcode/google-map", version = "3.8.2")
+@NpmPackage(value = "@flowingcode/google-map", version = "3.9.0")
 @NpmPackage(value = "@googlemaps/markerclusterer", version = "2.0.8")
 public class GoogleMapMarker extends Component {
 

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapPoint.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapPoint.java
@@ -28,7 +28,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @SuppressWarnings("serial")
 @Tag("google-map-point")
 @JsModule("@flowingcode/google-map/google-map-point.js")
-@NpmPackage(value = "@flowingcode/google-map", version = "3.8.2")
+@NpmPackage(value = "@flowingcode/google-map", version = "3.9.0")
 @NpmPackage(value = "@googlemaps/markerclusterer", version = "2.0.8")
 public class GoogleMapPoint extends Component {
 

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapPoly.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapPoly.java
@@ -39,7 +39,7 @@ import java.util.List;
 @Tag("google-map-poly")
 @JsModule("@flowingcode/google-map/google-map-poly.js")
 @JsModule("@flowingcode/google-map/google-map-point.js")
-@NpmPackage(value = "@flowingcode/google-map", version = "3.8.2")
+@NpmPackage(value = "@flowingcode/google-map", version = "3.9.0")
 @NpmPackage(value = "@googlemaps/markerclusterer", version = "2.0.8")
 public abstract class GoogleMapPoly extends Component {
 


### PR DESCRIPTION
Close #149.

This PR updates web-component version to [3.9.0](https://github.com/FlowingCode/google-map/releases/tag/3.9.0), this version adds support for right-click on mobile devices.

Component version was updated accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped addon version to 2.4.0-SNAPSHOT for upcoming release.
  * Upgraded the underlying Google Maps web component to version 3.9.0 across map, marker, point, and polyline components.

* **Bug Fixes**
  * Incorporates fixes included in the updated Google Maps web component.

* **Refactor**
  * Standardized dependency versions to align components with the latest Google Maps package for improved consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->