### PR TITLE
fix: add compatible constructor for GoogleMapPolyClickEvent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -555,7 +555,56 @@
 				</dependency>
 			</dependencies>
 		</profile>
-		
+
+		<profile>
+			<id>dance</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-clean-plugin</artifactId>
+						<configuration>
+							<filesets>
+								<fileset>
+									<directory>${project.basedir}</directory>
+									<includes>
+										<include>package.json</include>
+										<include>package-lock.json</include>
+										<include>tsconfig.json</include>
+										<include>tsconfig.json.*</include>
+										<include>types.d.ts</include>
+										<include>types.d.ts.*</include>
+										<include>vite.config.ts</include>
+										<include>vite.generated.ts</include>
+										<include>webpack.config.js</include>
+										<include>webpack.generated.js</include>
+									</includes>
+								</fileset>
+								<fileset>
+									<directory>${project.basedir}/frontend</directory>
+									<includes>
+										<include>index.html</include>
+									</includes>
+								</fileset>
+								<fileset>
+									<directory>${project.basedir}/frontend/generated</directory>
+								</fileset>
+								<fileset>
+									<directory>${project.basedir}/node_modules</directory>
+								</fileset>
+								<fileset>
+									<directory>${project.basedir}/src/main/bundles</directory>
+								</fileset>
+								<fileset>
+									<directory>${project.basedir}/src/main/dev-bundle</directory>
+								</fileset>
+							</filesets>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
     </profiles>
-    
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flowingcode.vaadin.addons</groupId>
     <artifactId>google-maps</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
     <name>Google Maps Addon</name>
     <description>Integration of google-map for Vaadin platform</description>
 

--- a/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapPoly.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/googlemaps/GoogleMapPoly.java
@@ -160,10 +160,38 @@ public abstract class GoogleMapPoly extends Component {
     private final double lat;
     private final double lon;
 
+    /**
+     * Creates a new event with the click coordinates as separate lat/lon values.
+     *
+     * @param source the polygon that was clicked
+     * @param fromClient whether the event originated on the client side
+     * @param lat the latitude of the click
+     * @param lon the longitude of the click
+     */
     public GoogleMapPolyClickEvent(
         GoogleMapPoly source,
         boolean fromClient,
-        @EventData(value = "event.detail.latLng") JsonValue latLng) {
+        @EventData("event.detail.latLng.lat()") double lat,
+        @EventData("event.detail.latLng.lng()") double lon) {
+      super(source);
+      this.lat = lat;
+      this.lon = lon;
+    }
+
+    /**
+     * Creates a new event with the click coordinates as a JSON value.
+     *
+     * @param source the polygon that was clicked
+     * @param fromClient whether the event originated on the client side
+     * @param latLng a JSON object containing {@code lat} and {@code lng} properties
+     * @deprecated since 2.5.0, for removal. Use
+     *     {@link #GoogleMapPolyClickEvent(GoogleMapPoly, boolean, double, double)} instead.
+     */
+    @Deprecated
+    public GoogleMapPolyClickEvent(
+        GoogleMapPoly source,
+        boolean fromClient,
+        JsonValue latLng) {
       super(source);
       lat = ((JsonObject) latLng).getNumber("lat");
       lon = ((JsonObject) latLng).getNumber("lng");


### PR DESCRIPTION
Close #180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Project version bumped to 2.5.0-SNAPSHOT
  * Added a build profile to clean frontend/build artifacts and generated files

* **Improvements**
  * Polygon click events now provide latitude and longitude as separate coordinate values
  * Previous single-payload polygon click event remains available but is deprecated
<!-- end of auto-generated comment: release notes by coderabbit.ai -->