### PR TITLE
build: upgrade lombok to 1.18.46 AND build: upgrade json-migration-helper to 0.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>com.flowingcode.vaadin</groupId>
             <artifactId>json-migration-helper</artifactId>
-            <version>0.9.2</version>
+            <version>0.9.5</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
         <jetty.version>9.4.36.v20210114</jetty.version>
         <flowingcode.commons.demo.version>3.9.0</flowingcode.commons.demo.version>
-        <lombok.version>1.18.40</lombok.version>
+        <lombok.version>1.18.46</lombok.version>
     </properties>
 	
     <organization>


### PR DESCRIPTION
See https://github.com/FlowingCode/AddonsInternal/issues/202#issuecomment-5122816040

>Latest lombok version is 1.18.46
>
> From lombok 1.18.44 release notes
>
> BUGFIX: On JDK25, val and @ExtensionMethod could sometimes cause erroneous errors (in that you see errors but compilation succeeds anyway) using javac https://github.com/projectlombok/lombok/issues/3947
>
>Currently the Ecosystem build fails
> https://github.com/mstahv/vaadin-ecosystem-build/issues/153